### PR TITLE
Fix 'mvn site' command

### DIFF
--- a/services/idp/pom.xml
+++ b/services/idp/pom.xml
@@ -26,7 +26,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>fediz-idp</artifactId>
-    <name>Apache Fediz IDP (Spring Security &amp; Spring Web Flow)</name>
+    <name>Apache Fediz IDP (Spring Security and Spring Web Flow)</name>
     <packaging>war</packaging>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
'mvn site' doesn't like the &amp;

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.2:site (default-site) on project fediz-idp: SiteToolException: Error parsing site descriptor: entity reference names can not start with character ' ' (position: START_DOCUMENT seen ...<project name="Apache Fediz IDP (Spring Security & ... @21:52) -> [Help 1
