### PR TITLE
Initialize BeanCreationException with causing exception

### DIFF
--- a/plugins/spring/src/main/java/org/apache/cxf/fediz/spring/FederationConfigImpl.java
+++ b/plugins/spring/src/main/java/org/apache/cxf/fediz/spring/FederationConfigImpl.java
@@ -65,7 +65,7 @@ public class FederationConfigImpl implements FederationConfig, ServletContextAwa
             configurator.loadConfig(this.configFile.getFile());
         } catch (Exception e) {
             LOG.error("Failed to parse '" + configFile.getDescription() + "'", e);
-            throw new BeanCreationException("Failed to parse '" + configFile.getDescription() + "'");
+            throw new BeanCreationException("Failed to parse '" + configFile.getDescription() + "'", e);
         }
     }
 


### PR DESCRIPTION
Not passing the root cause here will cause this exception to be displayed many times _without_
the real root case, instead suggesting that a malformed resource URL might be the culprit when instead
it is e.g. a non-validating fediz_config.xml XML file.
