### PR TITLE
Compilation error in oAuthAuthorizationData.jsp

### DIFF
--- a/services/oidc/src/main/webapp/WEB-INF/views/oAuthAuthorizationData.jsp
+++ b/services/oidc/src/main/webapp/WEB-INF/views/oAuthAuthorizationData.jsp
@@ -77,7 +77,7 @@
                             }
                         %>
 
-                        <h2>Would you like to grant <%= ESAPI.encoder().encodeForHTML(client.getApplicationName()) %><br />the following permissions:</h2>
+                        <h2>Would you like to grant <%= ESAPI.encoder().encodeForHTML(data.getApplicationName()) %><br />the following permissions:</h2>
 
                         <table> 
                             <%


### PR DESCRIPTION
Fix compilation error introduced in 'Adding ESAPI protection to OIDC'
commit.

We get this error when the screen oAuthAuthorizationData.jsp is displayed : 

```
Caused by: org.apache.jasper.JasperException: Unable to compile class for JSP: 

An error occurred at line: 80 in the jsp file: /WEB-INF/views/oAuthAuthorizationData.jsp
client cannot be resolved
77:                             }
78:                         %>
79: 
80:                         <h2>Would you like to grant <%= ESAPI.encoder().encodeForHTML(client.getApplicationName()) %><br />the following permissions:</h2>
81: 
82:                         <table> 
83:                             <%
```