### PR TITLE
FEDIZ-192 - customSTSParameter propagation

### DIFF
--- a/services/idp-core/src/main/java/org/apache/cxf/fediz/service/idp/STSUPAuthenticationProvider.java
+++ b/services/idp-core/src/main/java/org/apache/cxf/fediz/service/idp/STSUPAuthenticationProvider.java
@@ -135,10 +135,10 @@ public class STSUPAuthenticationProvider extends STSAuthenticationProvider {
         if (getCustomSTSParameter() != null) {
             HttpServletRequest request =
                     ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
-            HttpServletResponse response =
-                    ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getResponse();
             authRealmParameter = request.getParameter(getCustomSTSParameter());
             if (authRealmParameter == null) {
+                HttpServletResponse response =
+                        ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getResponse();
                 SavedRequest savedRequest = requestCache.getRequest(request, response);
                 String[] parameterValues = savedRequest.getParameterValues(this.getCustomSTSParameter());
                 if (parameterValues != null && parameterValues.length > 0) {


### PR DESCRIPTION
This fix enables propagating the customSTSParameter
SAML parameter to the Validator class.

The issue was caused by Spring Security which redirects
the user to a /login page (without the original parameters)

To handle this case, we :
 * get the custom parameter from HTTP parameters
   (as previously).
 * if not found we lookup in the Spring Security
   savedRequest (aka requestCache).