### PR TITLE
FEDIZ-194: NPE fix when using dynamicReg

### DIFF
--- a/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/clients/ClientRegistrationService.java
+++ b/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/clients/ClientRegistrationService.java
@@ -422,14 +422,16 @@ public class ClientRegistrationService {
 
     public void init() {
         for (Client c : clientProvider.getClients(null)) {
-            String userName = c.getResourceOwnerSubject().getLogin();
-            getClientRegistrations(userName).add(c);
-            Set<String> names = clientNames.get(userName);
-            if (names == null) {
-                names = new HashSet<>();
-                clientNames.put(userName, names);
+            if (c.getResourceOwnerSubject() != null) {
+                String userName = c.getResourceOwnerSubject().getLogin();
+                getClientRegistrations(userName).add(c);
+                Set<String> names = clientNames.get(userName);
+                if (names == null) {
+                    names = new HashSet<>();
+                    clientNames.put(userName, names);
+                }
+                names.add(c.getApplicationName());
             }
-            names.add(c.getApplicationName());
         }
     }
 


### PR DESCRIPTION
Fix NPE on fediz OIDC module startup after
using dynamic Client Registration.

When using dynamic Client Registration, client.resourceOwnerSubject
is null.
We now check this field and display only manually
registered Clients in Fediz UI.