### PR TITLE
OIDC logout should use post_logout_redirect_uris

### DIFF
--- a/services/oidc/src/main/webapp/WEB-INF/views/client.jsp
+++ b/services/oidc/src/main/webapp/WEB-INF/views/client.jsp
@@ -156,8 +156,8 @@
 <b>Logout URL</b>
 </td>
 <td>
-<% if (client.getProperties().get("client_logout_uri") != null) { %>
-           <%=    client.getProperties().get("client_logout_uri") %>
+<% if (client.getProperties().get("post_logout_redirect_uris") != null) { %>
+           <%=    client.getProperties().get("post_logout_redirect_uris") %>
 <% } %>
 </td>
 </tr>


### PR DESCRIPTION
Fediz uses both post_logout_redirect_uris and
client_logout_uri Client properties for logout.

It should only use post_logout_redirect_uris
as per openid-connect-frontchannel-1_0-02.html.

Also post_logout_redirect_uris is a list of acceptable
uris, the post_logout_redirect_uri must be
a value inside this list.