### PR TITLE
OIDC Logout URI should accept multiple Urls

### DIFF
--- a/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/clients/ClientRegistrationService.java
+++ b/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/clients/ClientRegistrationService.java
@@ -286,8 +286,11 @@ public class ClientRegistrationService {
             }
             // Client Logout URI
             if (!StringUtils.isEmpty(logoutURI)) {
-                if (!isValidURI(logoutURI, false)) {
-                    throwInvalidRegistrationException("An invalid logout URI was specified: " + logoutURI);
+                String[] logoutUris = logoutURI.split(" ");
+                for (String uri : logoutUris) {
+                    if (!isValidURI(uri, false)) {
+                        throwInvalidRegistrationException("An invalid logout URI was specified: " + uri);
+                    }
                 }
                 //TODO: replace this code with newClient.setLogoutUri() once it becomes available
                 newClient.getProperties().put("post_logout_redirect_uris", logoutURI);


### PR DESCRIPTION
Logout URI should accept multiple URLs separated
with a space.

At the moment, Fediz UI rejects multiple logout Urls