### PR TITLE
FEDIZ-212: fix logout when no httpSession present

### DIFF
--- a/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/logout/LogoutService.java
+++ b/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/logout/LogoutService.java
@@ -58,6 +58,7 @@ public class LogoutService extends JoseJwtConsumer {
     private FedizSubjectCreator subjectCreator = new FedizSubjectCreator();
     private BackChannelLogoutHandler backChannelLogoutHandler;
     private List<LogoutHandler> logoutHandlers;
+    private boolean allowAnonymousLogout;
 
     @POST
     public Response initiateLogoutPost(MultivaluedMap<String, String> params) {
@@ -73,7 +74,7 @@ public class LogoutService extends JoseJwtConsumer {
         IdToken idTokenHint = getIdTokenHint(params);
         Client client = getClient(params, idTokenHint);
 
-        if (mc.getSecurityContext().getUserPrincipal() != null) {
+        if (!allowAnonymousLogout || mc.getSecurityContext().getUserPrincipal() != null) {
             OidcUserSubject subject = subjectCreator.createUserSubject(mc, params);
 
             if (backChannelLogoutHandler != null) {
@@ -179,6 +180,10 @@ public class LogoutService extends JoseJwtConsumer {
     }
     public void setBackChannelLogoutHandler(BackChannelLogoutHandler handler) {
         this.backChannelLogoutHandler = handler;
+    }
+
+    public void setAllowAnonymousLogout(boolean allowAnonymousLogout) {
+        this.allowAnonymousLogout = allowAnonymousLogout;
     }
 
     public void close() {

--- a/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/logout/LogoutService.java
+++ b/services/oidc/src/main/java/org/apache/cxf/fediz/service/oidc/logout/LogoutService.java
@@ -71,18 +71,22 @@ public class LogoutService extends JoseJwtConsumer {
     protected Response doInitiateLogout(MultivaluedMap<String, String> params) {
 
         IdToken idTokenHint = getIdTokenHint(params);
-        OidcUserSubject subject = subjectCreator.createUserSubject(mc, params);
-
         Client client = getClient(params, idTokenHint);
-        if (backChannelLogoutHandler != null) {
-            backChannelLogoutHandler.handleLogout(client, subject, idTokenHint);
-        }
-        if (logoutHandlers != null) {
 
-            for (LogoutHandler handler : logoutHandlers) {
-                handler.handleLogout(client, subject);
+        if (mc.getSecurityContext().getUserPrincipal() != null) {
+            OidcUserSubject subject = subjectCreator.createUserSubject(mc, params);
+
+            if (backChannelLogoutHandler != null) {
+                backChannelLogoutHandler.handleLogout(client, subject, idTokenHint);
+            }
+            if (logoutHandlers != null) {
+
+                for (LogoutHandler handler : logoutHandlers) {
+                    handler.handleLogout(client, subject);
+                }
             }
         }
+
         // Clear OIDC session now
         mc.getHttpServletRequest().getSession().invalidate();
 
@@ -113,7 +117,7 @@ public class LogoutService extends JoseJwtConsumer {
         String clientLogoutUriParam = params.getFirst(CLIENT_LOGOUT_URI);
         if (uris.length > 1) {
             if (clientLogoutUriParam == null
-                || !new HashSet<>(Arrays.asList(uris)).contains(clientLogoutUriParam)) {
+                    || !new HashSet<>(Arrays.asList(uris)).contains(clientLogoutUriParam)) {
                 throw new BadRequestException();
             }
             uriStr = clientLogoutUriParam;


### PR DESCRIPTION
When no httpSession is present, LogoutService
throws a OAuthServiceException.

This can be an issue if logout is called
multiples times (i.e. from different OIDC Clients)