### PR TITLE
IDP maxParameter size is set only if positive

### DIFF
--- a/services/idp-core/src/main/java/org/apache/cxf/fediz/service/idp/service/jpa/IdpDAOJPAImpl.java
+++ b/services/idp-core/src/main/java/org/apache/cxf/fediz/service/idp/service/jpa/IdpDAOJPAImpl.java
@@ -333,7 +333,10 @@ public class IdpDAOJPAImpl implements IdpDAO {
         idp.setRpSingleSignOutCleanupConfirmation(entity.isRpSingleSignOutCleanupConfirmation());
         idp.setAutomaticRedirectToRpAfterLogout(entity.isAutomaticRedirectToRpAfterLogout());
         idp.setDisableLogoutAddressValidation(entity.isDisableLogoutAddressValidation());
-        idp.setMaxParameterSize(entity.getMaxParameterSize());
+
+        if (entity.getMaxParameterSize() > 0) {
+            idp.setMaxParameterSize(entity.getMaxParameterSize());
+        }
 
         if (expandList != null && (expandList.contains("all") || expandList.contains("applications"))) {
             for (ApplicationEntity item : entity.getApplications()) {


### PR DESCRIPTION
maxParameter size should be set only if positive,
otherwise, we'll use default value.