### PR TITLE
[FEDIZ-217] Fix SAML authentication in Plugin

### DIFF
--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/FederationConstants.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/FederationConstants.java
@@ -150,6 +150,12 @@ public final class FederationConstants extends FedizConstants {
      * element.
      */
     public static final String PARAM_RESULT_PTR = "wresultptr";
+    
+    /**
+     * This OPTIONAL session attribute prefix append to request RelayState value specifies 
+     * initial RequestState created before redirecting to IDP
+     */
+    public static final String SESSION_SAVED_REQUEST_STATE_PREFIX = "SAVED_REQUEST_STATE_";
 
     public static final Map<String, URI> AUTH_TYPE_MAP;
     static {

--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
@@ -134,6 +134,7 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
                 tokenStream = CompressionUtils.inflate(deflatedToken);
             }
         } catch (DataFormatException ex) {
+            LOG.warn("Invalid data format", ex);
             throw new ProcessingException(TYPE.INVALID_REQUEST);
         }
 
@@ -144,7 +145,7 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
             el = doc.getDocumentElement();
 
         } catch (Exception e) {
-            LOG.warn("Failed to parse token: " + e.getMessage());
+            LOG.warn("Failed to parse token", e);
             throw new ProcessingException(TYPE.INVALID_REQUEST);
         }
 

--- a/plugins/tomcat8/src/main/java/org/apache/cxf/fediz/tomcat8/FederationAuthenticator.java
+++ b/plugins/tomcat8/src/main/java/org/apache/cxf/fediz/tomcat8/FederationAuthenticator.java
@@ -43,6 +43,7 @@ import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.cxf.fediz.core.FederationConstants;
 import org.apache.cxf.fediz.core.FedizPrincipal;
+import org.apache.cxf.fediz.core.RequestState;
 import org.apache.cxf.fediz.core.config.FedizConfigurator;
 import org.apache.cxf.fediz.core.config.FedizContext;
 import org.apache.cxf.fediz.core.exception.ProcessingException;
@@ -299,7 +300,7 @@ public class FederationAuthenticator extends FormAuthenticator {
 
                 // Save original request in our session
                 try {
-                    saveRequest(request, redirectionResponse.getRequestState().getState());
+                    saveRequest(request, redirectionResponse.getRequestState());
                 } catch (IOException ioe) {
                     LOG.debug("Request body too big to save during authentication");
                     response.sendError(HttpServletResponse.SC_FORBIDDEN, sm
@@ -333,7 +334,8 @@ public class FederationAuthenticator extends FormAuthenticator {
         return false;
     }
 
-    protected void saveRequest(Request request, String contextId) throws IOException {
+    protected void saveRequest(Request request, RequestState requestState) throws IOException {
+        String contextId = requestState.getState();
         String uri = request.getDecodedRequestURI();
         Session session = request.getSessionInternal(true);
         if (session != null) {
@@ -352,6 +354,9 @@ public class FederationAuthenticator extends FormAuthenticator {
                 sb.append(saved.getQueryString());
             }
             session.setNote(SESSION_SAVED_URI_PREFIX + contextId, sb.toString());
+            //we set Request State as session attribute for later retrieval in SigninHandler
+            request.getSession().setAttribute(
+                FederationConstants.SESSION_SAVED_REQUEST_STATE_PREFIX + requestState.getState(), requestState);
         }
     }
 


### PR DESCRIPTION
RequestState needs to be saved before redirecting to IDP in order to be
retrieved when IDP post back authentication token.