### PR TITLE
A proposed fix for FEDIZ-243

### DIFF
--- a/plugins/tomcat/src/main/java/org/apache/cxf/fediz/tomcat/FederationAuthenticator.java
+++ b/plugins/tomcat/src/main/java/org/apache/cxf/fediz/tomcat/FederationAuthenticator.java
@@ -267,11 +267,6 @@ public class FederationAuthenticator extends FormAuthenticator {
         Session session = request.getSessionInternal();
         LOG.debug("Restore request from session '{}'", session.getIdInternal());
 
-        // Get principal from session, register, and then remove it
-        Principal principal = (Principal)session.getNote(Constants.FORM_PRINCIPAL_NOTE);
-        register(request, response, principal, FederationConstants.WSFED_METHOD, null, null);
-        request.removeNote(Constants.FORM_PRINCIPAL_NOTE);
-
         if (restoreRequest(request)) {
             LOG.debug("Proceed to restored request");
             return true;

--- a/plugins/tomcat/src/main/java/org/apache/cxf/fediz/tomcat/handler/TomcatSigninHandler.java
+++ b/plugins/tomcat/src/main/java/org/apache/cxf/fediz/tomcat/handler/TomcatSigninHandler.java
@@ -66,8 +66,8 @@ public class TomcatSigninHandler extends SigninHandler<FedizPrincipal> {
 
         Session session = ((Request)request).getSessionInternal();
 
-        // Save the authenticated Principal in our session
-        session.setNote(Constants.FORM_PRINCIPAL_NOTE, principal);
+        // Register the authenticated Principal
+        register((Request) request, response, principal, FederationConstants.WSFED_METHOD, null, null);
 
         // Save Federation response in our session
         session.setNote(FederationAuthenticator.FEDERATION_NOTE, wfRes);


### PR DESCRIPTION
Get rid of Constants.FORM_PRINCIPAL_NOTE that is not used anymore in
form authenticator

Note that FederationAuthenticator will not work anymore with older tomcat version than 8.5.50 and 9.0.30. People that are using old tomcat version would have to use old version of the plugin.
There could be an alternative change that would keep compatibility but i am not sure it is desirable, as 
FormAuthenticator has been changed for a reason. 