### PR TITLE
Support SAML encrypted tokens

### DIFF
--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/config/SAMLProtocol.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/config/SAMLProtocol.java
@@ -103,6 +103,10 @@ public class SAMLProtocol extends Protocol {
     public boolean isDoNotEnforceKnownIssuer() {
         return getSAMLProtocol().isDoNotEnforceKnownIssuer();
     }
+    
+    public boolean isDoNotEnforceAssertionsSigned() {
+        return getSAMLProtocol().isDoNotEnforceAssertionsSigned();
+    }
 
     public void setDoNotEnforceKnownIssuer(boolean doNotEnforceKnownIssuer) {
         getSAMLProtocol().setDoNotEnforceKnownIssuer(doNotEnforceKnownIssuer);

--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
@@ -434,7 +434,11 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
             ssoResponseValidator.setIssuerIDP(requestState != null ? requestState.getIdpServiceAddress() : null);
             ssoResponseValidator.setRequestId(requestState != null ? requestState.getRequestId() : null);
             ssoResponseValidator.setSpIdentifier(requestState != null ? requestState.getIssuerId() : null);
-            ssoResponseValidator.setEnforceAssertionsSigned(true);
+            
+            boolean doNotEnforceAssertionsSigned =
+                    ((SAMLProtocol)config.getProtocol()).isDoNotEnforceAssertionsSigned();
+            ssoResponseValidator.setEnforceAssertionsSigned(!doNotEnforceAssertionsSigned);
+            
             ssoResponseValidator.setReplayCache(config.getTokenReplayCache());
 
             return ssoResponseValidator.validateSamlResponse(samlResponse, false);

--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/processor/SAMLProcessorImpl.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.Signature;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +49,7 @@ import org.apache.cxf.fediz.core.TokenValidator;
 import org.apache.cxf.fediz.core.TokenValidatorRequest;
 import org.apache.cxf.fediz.core.TokenValidatorResponse;
 import org.apache.cxf.fediz.core.config.FedizContext;
+import org.apache.cxf.fediz.core.config.KeyManager;
 import org.apache.cxf.fediz.core.config.SAMLProtocol;
 import org.apache.cxf.fediz.core.exception.ProcessingException;
 import org.apache.cxf.fediz.core.exception.ProcessingException.TYPE;
@@ -57,6 +59,7 @@ import org.apache.cxf.fediz.core.samlsso.SAMLPRequestBuilder;
 import org.apache.cxf.fediz.core.samlsso.SAMLProtocolResponseValidator;
 import org.apache.cxf.fediz.core.samlsso.SAMLSSOResponseValidator;
 import org.apache.cxf.fediz.core.samlsso.SSOValidatorResponse;
+import org.apache.cxf.fediz.core.util.CertsUtils;
 import org.apache.cxf.fediz.core.util.DOMUtils;
 import org.apache.wss4j.common.crypto.Crypto;
 import org.apache.wss4j.common.ext.WSSecurityException;
@@ -65,10 +68,20 @@ import org.apache.wss4j.common.saml.SamlAssertionWrapper;
 import org.apache.wss4j.common.util.DOM2Writer;
 import org.apache.wss4j.dom.WSConstants;
 import org.opensaml.core.xml.XMLObject;
-import org.opensaml.saml.common.xml.SAMLConstants;
+import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnRequest;
+import org.opensaml.saml.saml2.core.EncryptedAssertion;
 import org.opensaml.saml.saml2.core.LogoutRequest;
 import org.opensaml.saml.saml2.core.StatusResponseType;
+import org.opensaml.saml.saml2.encryption.Decrypter;
+import org.opensaml.saml.saml2.encryption.EncryptedElementTypeEncryptedKeyResolver;
+import org.opensaml.security.x509.BasicX509Credential;
+import org.opensaml.xmlsec.encryption.support.ChainingEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.EncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.InlineEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.SimpleKeyInfoReferenceEncryptedKeyResolver;
+import org.opensaml.xmlsec.encryption.support.SimpleRetrievalMethodEncryptedKeyResolver;
+import org.opensaml.xmlsec.keyinfo.impl.StaticKeyInfoCredentialResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +185,9 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
         if (!(responseObject instanceof org.opensaml.saml.saml2.core.Response)) {
             throw new ProcessingException(TYPE.INVALID_REQUEST);
         }
+        
+        // Decrypt encrypted assertions
+        decryptEncryptedAssertions((org.opensaml.saml.saml2.core.Response) responseObject, config);
 
         // Validate the Response
         validateSamlResponseProtocol((org.opensaml.saml.saml2.core.Response)responseObject, config);
@@ -182,14 +198,13 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
 
         // Validate the internal assertion(s)
         TokenValidatorResponse validatorResponse = null;
-        List<Element> assertions =
-            DOMUtils.getChildrenWithName(el, SAMLConstants.SAML20_NS, "Assertion");
+        List<Assertion> assertions = ((org.opensaml.saml.saml2.core.Response)responseObject).getAssertions();
 
         if (assertions.isEmpty()) {
             LOG.debug("No Assertion extracted from SAML Response");
             throw new ProcessingException(TYPE.INVALID_REQUEST);
         }
-        Element token = assertions.get(0);
+        Element token = assertions.get(0).getDOM();
 
         List<TokenValidator> validators = protocol.getTokenValidators();
         for (TokenValidator validator : validators) {
@@ -252,6 +267,62 @@ public class SAMLProcessorImpl extends AbstractFedizProcessor {
                 validatorResponse.getUniqueTokenId());
 
         return fedResponse;
+    }
+
+    private void decryptEncryptedAssertions(org.opensaml.saml.saml2.core.Response responseObject, FedizContext config)
+            throws ProcessingException {
+        if (responseObject.getEncryptedAssertions() != null && !responseObject.getEncryptedAssertions().isEmpty()) {
+            KeyManager decryptionKeyManager = config.getDecryptionKey();
+            if (decryptionKeyManager == null || decryptionKeyManager.getCrypto() == null) {
+                LOG.debug("We must have a decryption Crypto instance configured to decrypt encrypted tokens");
+                throw new ProcessingException(TYPE.BAD_REQUEST);
+            }
+            String keyPassword = decryptionKeyManager.getKeyPassword();
+            if (keyPassword == null) {
+                LOG.debug("We must have a decryption key password to decrypt encrypted tokens");
+                throw new ProcessingException(TYPE.BAD_REQUEST);
+            }
+     
+            String keyAlias = decryptionKeyManager.getKeyAlias();
+            if (keyAlias == null) {
+                LOG.debug("No alias configured for decrypt");
+                throw new ProcessingException(TYPE.BAD_REQUEST);
+            }
+            
+            try {
+                // Get the private key
+                PrivateKey privateKey = decryptionKeyManager.getCrypto().getPrivateKey(keyAlias, keyPassword);
+                if (privateKey == null) {
+                    LOG.debug("No private key available");
+                    throw new ProcessingException(TYPE.BAD_REQUEST);
+                }
+                
+                BasicX509Credential cred = new BasicX509Credential(
+                    CertsUtils.getX509CertificateFromCrypto(decryptionKeyManager.getCrypto(), keyAlias));
+                cred.setPrivateKey(privateKey);
+                
+                StaticKeyInfoCredentialResolver resolver = new StaticKeyInfoCredentialResolver(cred);
+                
+                ChainingEncryptedKeyResolver keyResolver = new ChainingEncryptedKeyResolver(
+                        Arrays.<EncryptedKeyResolver>asList(
+                                new InlineEncryptedKeyResolver(),
+                                new EncryptedElementTypeEncryptedKeyResolver(), 
+                                new SimpleRetrievalMethodEncryptedKeyResolver(),
+                                new SimpleKeyInfoReferenceEncryptedKeyResolver()));
+                
+                Decrypter decrypter = new Decrypter(null, resolver, keyResolver);
+                
+                for (EncryptedAssertion encryptedAssertion : responseObject.getEncryptedAssertions()) {
+                
+                    Assertion decrypted = decrypter.decrypt(encryptedAssertion);
+                    LOG.debug("Decrypted:" + DOM2Writer.nodeToString(decrypted.getDOM()));
+                    responseObject.getAssertions().add(decrypted);
+                }
+            } catch (Exception e) {
+                LOG.debug("Cannot decrypt assertions", e);
+                throw new ProcessingException(TYPE.BAD_REQUEST);
+            }
+        }
     }
 
     private FedizResponse processSignOutResponse(FedizRequest request, FedizContext config) throws ProcessingException {

--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/saml/SAMLTokenValidator.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/saml/SAMLTokenValidator.java
@@ -19,7 +19,9 @@
 
 package org.apache.cxf.fediz.core.saml;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -339,12 +341,18 @@ public class SAMLTokenValidator implements TokenValidator {
                 // Value of Attribute Name not fully qualified
                 // if NameFormat is http://schemas.xmlsoap.org/ws/2005/05/identity/claims
                 // but ClaimType value must be fully qualified as Namespace attribute goes away
-                URI attrName = URI.create(attribute.getName());
+                String attributeName;
+                try {
+                    attributeName = URLEncoder.encode(attribute.getName(), "UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    attributeName = attribute.getName();
+                }
+                URI attrName = URI.create(attributeName);
                 if (ClaimTypes.URI_BASE.toString().equals(attribute.getNameFormat())
                     && !attrName.isAbsolute()) {
-                    c.setClaimType(URI.create(ClaimTypes.URI_BASE + "/" + attribute.getName()));
+                    c.setClaimType(URI.create(ClaimTypes.URI_BASE + "/" + attributeName));
                 } else {
-                    c.setClaimType(URI.create(attribute.getName()));
+                    c.setClaimType(attrName);
                 }
                 c.setIssuer(assertion.getIssuer().getNameQualifier());
 

--- a/plugins/core/src/main/resources/schemas/FedizConfig.xsd
+++ b/plugins/core/src/main/resources/schemas/FedizConfig.xsd
@@ -172,6 +172,7 @@
                     <xs:element ref="disableDeflateEncoding" />
                     <xs:element ref="disableClientAddressCheck" />
                     <xs:element ref="doNotEnforceKnownIssuer" />
+                    <xs:element ref="doNotEnforceAssertionsSigned" />
                     <xs:element ref="issuerLogoutURL" />
                 </xs:sequence>
                 <xs:attribute name="version" use="required" type="xs:string" />
@@ -189,6 +190,7 @@
     <xs:element name="authnRequestBuilder" type="xs:string" />
     <xs:element name="disableDeflateEncoding" type="xs:boolean" />
     <xs:element name="doNotEnforceKnownIssuer" type="xs:boolean" />
+    <xs:element name="doNotEnforceAssertionsSigned" type="xs:boolean" />
     <xs:element name="issuerLogoutURL" type="xs:string" />
     <xs:element name="disableClientAddressCheck" type="xs:boolean"/>
 


### PR DESCRIPTION
While testing fediz tomcat plugin with Sign&go IDP, I was facing issues as SAML Encrypted token are not supported.
The first commit is adding support for Encrypted assertion.

Then I was still facing issues, as encrypted assertion remove the necessity to sign the assertion.
The second commit proposes a way to disable assertions signature validation

The last issue I noticed was about an attribute statement with a space inside the name. The fix for that is the 3rd commit (I am not 100 % sure having space in attribute name is valid so I separate the commit)