### PR TITLE
escape cache key

### DIFF
--- a/plugins/core/src/main/java/org/apache/cxf/fediz/core/config/FedizContext.java
+++ b/plugins/core/src/main/java/org/apache/cxf/fediz/core/config/FedizContext.java
@@ -246,7 +246,8 @@ public class FedizContext implements Closeable {
             return replayCache;
         }
         final String replayCacheString = config.getTokenReplayCache();
-        final String cacheKey = CACHE_KEY_PREFIX + '-' + config.getName();
+        // replace special characters
+        final String cacheKey = CACHE_KEY_PREFIX + '-' + config.getName().replace('/', '_');
         try {
             final Path diskstorePath = Files.createTempDirectory("fediz");
             if (replayCacheString == null || replayCacheString.isEmpty()) {


### PR DESCRIPTION
Cache key based on config name and usually started with slash. In case of Infinispan the cli uses slash as resource separator therefore chache cannot be checked easy way